### PR TITLE
Posts: Removed commented-out line that reversed post data array since…

### DIFF
--- a/client/src/components/feed-post-container/feed-post-container.component.tsx
+++ b/client/src/components/feed-post-container/feed-post-container.component.tsx
@@ -34,6 +34,7 @@ interface FeedPostContainerProps {
   getPostReactionsError: PostError | null;
   createPostReactionStart: typeof createPostReactionStart;
   getPostReactionsStart: typeof getPostReactionsStart;
+  ref?: (node: any) => void;
 }
 
 export interface UserInfoData {

--- a/client/src/redux/post/post.sagas.ts
+++ b/client/src/redux/post/post.sagas.ts
@@ -81,14 +81,14 @@ export function* updateProfilePhoto({
 }
 
 export function* getPostData({
-  payload: { userId, dataReqType, pagesToSkip, limit },
+  payload: { userId, dataReqType, pageToShow, limit },
 }: {
   payload: PostDataReq;
 }): any {
   try {
     const { data }: { data: Post[] } = yield axios.post('/api/posts/data', {
       userId,
-      pagesToSkip,
+      pageToShow,
       limit,
     });
 

--- a/client/src/redux/post/post.types.ts
+++ b/client/src/redux/post/post.types.ts
@@ -89,7 +89,7 @@ export enum DataRequestType {
 export interface PostDataReq {
   userId: string;
   dataReqType: DataRequestType;
-  pagesToSkip?: number;
+  pageToShow?: number;
   limit?: number;
 }
 

--- a/client/src/redux/post/post.utils.ts
+++ b/client/src/redux/post/post.utils.ts
@@ -16,6 +16,10 @@ export const addPostDataToFeedArray = (
 ) => {
   for (let el of postDataFeedArray) {
     if (el.length && el[0].s3Key === postData[0].s3Key) {
+      if (el[0].id !== postData[0].id) {
+        el = el.concat(...postData);
+      }
+
       return [...postDataFeedArray];
     }
   }
@@ -29,6 +33,10 @@ export const addPostReactionsToOuterReactionsArray = (
 ) => {
   for (let el of postReactionsOuterArray) {
     if (el.length && el[0].postId === postReactions[0].postId) {
+      if (el[0].id !== postReactions[0].id) {
+        el = el.concat(...postReactions);
+      }
+
       return [...postReactionsOuterArray];
     }
   }

--- a/posts/src/routes/data.ts
+++ b/posts/src/routes/data.ts
@@ -14,8 +14,8 @@ router.post(
   currentUser,
   async (req: Request, res: Response) => {
     const userId: string = req.body.userId;
-    const pagesToSkip = req.body.pagesToSkip || 0;
-    const limit = req.body.limit || 0;
+    const pageToShow = req.body.pageToShow || null;
+    const limit = req.body.limit || null;
 
     if (!userId) {
       throw new BadRequestError('No user ID was provided.');
@@ -23,19 +23,17 @@ router.post(
 
     let posts;
 
-    if (pagesToSkip && limit) {
+    if (pageToShow && limit) {
       posts = await Post.find({ userId, archived: { $ne: true } }, null, {
         sort: { _id: -1 },
       })
         .limit(limit)
-        .skip(pagesToSkip);
+        .skip((pageToShow - 1) * limit);
     } else {
       posts = await Post.find({ userId, archived: { $ne: true } }, null, {
         sort: { _id: -1 },
       });
     }
-
-    // posts = posts.reverse();
 
     console.log(posts);
 


### PR DESCRIPTION
… each query variation now has reverse sort order defined in get post data route handler. Client: Updated post types and sagas, updated post utils to allow concatatenation of inner post (and reaction) arrays within parent arrays. Added useRef and useCallback hooks for tracking when the last post rendered element is in view, for lazy loading in feed-page component