### PR TITLE
Fixes to prevent other post modal data cache objects to be removed wh…

### DIFF
--- a/client/src/components/feed-post-container/feed-post-container.component.tsx
+++ b/client/src/components/feed-post-container/feed-post-container.component.tsx
@@ -270,8 +270,8 @@ export const FeedPostContainer: React.FC<FeedPostContainerProps> = ({
     if (
       postReactionConfirm &&
       postReactionConfirm.message === 'Post liked successfully!' &&
-      postReactionConfirm.postId === postId &&
-      postModalProps.id
+      postId &&
+      postReactionConfirm.postId === postId
     ) {
       clearPostReactions();
 
@@ -292,8 +292,8 @@ export const FeedPostContainer: React.FC<FeedPostContainerProps> = ({
     if (
       deleteReactionConfirm &&
       deleteReactionConfirm.message === 'Like removed successfully!' &&
-      deleteReactionConfirm.postId === postId &&
-      postModalProps.id
+      postId &&
+      deleteReactionConfirm.postId === postId
     ) {
       clearPostReactions();
 
@@ -314,7 +314,8 @@ export const FeedPostContainer: React.FC<FeedPostContainerProps> = ({
     if (
       postReactionConfirm &&
       postReactionConfirm.message === 'Post comment created successfully!' &&
-      postId
+      postId &&
+      postReactionConfirm.postId === postId
     ) {
       clearPostReactions();
 
@@ -330,7 +331,8 @@ export const FeedPostContainer: React.FC<FeedPostContainerProps> = ({
     if (
       deleteReactionConfirm &&
       deleteReactionConfirm.message === 'Comment removed successfully!' &&
-      postId
+      postId &&
+      deleteReactionConfirm.postId === postId
     ) {
       clearPostReactions();
 

--- a/client/src/components/post-modal/post-modal.component.tsx
+++ b/client/src/components/post-modal/post-modal.component.tsx
@@ -366,7 +366,8 @@ export const PostModal: React.FC<PostModalProps> = ({
     if (
       postReactionConfirm &&
       postReactionConfirm.message === 'Post liked successfully!' &&
-      localPostId
+      localPostId &&
+      postReactionConfirm.postId === localPostId
     ) {
       clearPostReactions();
 
@@ -389,7 +390,8 @@ export const PostModal: React.FC<PostModalProps> = ({
     if (
       deleteReactionConfirm &&
       deleteReactionConfirm.message === 'Like removed successfully!' &&
-      localPostId
+      localPostId &&
+      deleteReactionConfirm.postId === localPostId
     ) {
       clearPostReactions();
 
@@ -412,7 +414,8 @@ export const PostModal: React.FC<PostModalProps> = ({
     if (
       postReactionConfirm &&
       postReactionConfirm.message === 'Post comment created successfully!' &&
-      localPostId
+      localPostId &&
+      postReactionConfirm.postId === localPostId
     ) {
       clearPostReactions();
 
@@ -429,7 +432,8 @@ export const PostModal: React.FC<PostModalProps> = ({
     if (
       deleteReactionConfirm &&
       deleteReactionConfirm.message === 'Comment removed successfully!' &&
-      localPostId
+      localPostId &&
+      deleteReactionConfirm.postId === localPostId
     ) {
       clearPostReactions();
 


### PR DESCRIPTION
…en a particular post modal data object needs to be removed after its corresponding post is updated in a post-modal or feed-post-container component